### PR TITLE
remove dconf access

### DIFF
--- a/com.rawtherapee.RawTherapee.yaml
+++ b/com.rawtherapee.RawTherapee.yaml
@@ -20,11 +20,6 @@ finish-args:
   # Access to temporary files
   # Share data between RawTherapee and external editors, especially GIMP
   - --filesystem=/tmp
-  # Dconf access
-  - --filesystem=xdg-run/dconf
-  - --filesystem=~/.config/dconf:ro
-  - --talk-name=ca.desrt.dconf
-  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   # Host commands access
   # for flatpak-spawn
   # Allow to use GIMP from the host as an external tool to edit photos


### PR DESCRIPTION
See: https://github.com/flathub/flathub/issues/1040
Migration not necessary, rawtherapee does not store its settings with dconf