### PR TITLE
Follow upstream build instructions more closely

### DIFF
--- a/com.rawtherapee.RawTherapee.yaml
+++ b/com.rawtherapee.RawTherapee.yaml
@@ -131,8 +131,8 @@ modules:
       - --enable-maintainer-mode
     sources:
       - type: archive
-        url: https://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.24/gtkmm-3.24.2.tar.xz
-        sha256: 6d71091bcd1863133460d4188d04102810e9123de19706fb656b7bb915b4adc3
+        url: https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.7.tar.xz
+        sha256: 1d7a35af9c5ceccacb244ee3c2deb9b245720d8510ac5c7e6f4b6f9947e6789c
       - type: shell
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} "build/";
@@ -186,6 +186,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DCACHE_NAME_SUFFIX=""
+      - -DCMAKE_CXX_FLAGS=-O3
     sources:
       - type: archive
         url: https://github.com/Beep6581/RawTherapee/releases/download/5.9/rawtherapee-5.9.tar.xz


### PR DESCRIPTION
According to http://rawtherapee.com/downloads/5.9/#news-relevant-to-package-maintainers there are these suggestions for package maintainers, that were not being followed here:

- Avoid the buggy GTK+ versions 3.24.2 - 3.24.6.
- Build RawTherapee with `-O3` flag.
- Download sources from https://rawtherapee.com/shared/source/ instead of github release tarballs.

So this patch should make the builds more close to upstream recommendations.