### PR TITLE
Add patch to mitigate ABI break of libjpeg-turbo

### DIFF
--- a/0001-jpeg-turbo.patch
+++ b/0001-jpeg-turbo.patch
@@ -1,0 +1,95 @@
+From efdc5bce3b9794847093baeb040937ab55eba86e Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 04:27:10 -0700
+Subject: [PATCH 1/2] Fix linking with jpeg-turbo
+
+patch via Termux PR
+https://github.com/termux-user-repository/tur/pull/1027
+---
+ rtengine/jdatasrc.cc | 28 ++--------------------------
+ 1 file changed, 2 insertions(+), 26 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index fa13b9dd1..a0d12657f 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -247,20 +247,6 @@ my_error_exit (j_common_ptr cinfo)
+ #endif
+ }
+ 
+-
+-#ifdef _WIN32
+-#define JVERSION	"6b  27-Mar-1998"
+-#define JCOPYRIGHT_SHORT	"(C) 1998, Thomas G. Lane"
+-#define JMESSAGE(code,string)	string ,
+-
+-const char * const jpeg_std_message_table[] = {
+-#include "jerror.h"
+-  NULL
+-};
+-#else
+-extern const char * const jpeg_std_message_table[];
+-#endif
+-
+ /*
+  * Actual output of an error or trace message.
+  * Applications may override this method to send JPEG messages somewhere
+@@ -409,24 +395,14 @@ reset_error_mgr (j_common_ptr cinfo)
+ GLOBAL(struct jpeg_error_mgr *)
+ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ {
++    err = jpeg_std_error(err);
+ 
++    /* override these functions */
+     err->error_exit = my_error_exit;
+     err->emit_message = emit_message;
+     err->output_message = output_message;
+     err->format_message = format_message;
+     err->reset_error_mgr = reset_error_mgr;
+ 
+-    err->trace_level = 0;     /* default = no tracing */
+-    err->num_warnings = 0;    /* no warnings emitted yet */
+-    err->msg_code = 0;        /* may be useful as a flag for "no error" */
+-
+-    /* Initialize message table pointers */
+-    err->jpeg_message_table = jpeg_std_message_table;
+-    err->last_jpeg_message = (int) JMSG_LASTMSGCODE - 1;
+-
+-    err->addon_message_table = nullptr;
+-    err->first_addon_message = 0; /* for safety */
+-    err->last_addon_message = 0;
+-
+     return err;
+ }
+-- 
+2.45.1
+
+
+From 7789a8574b454ebd874522a70930ae4b40726da4 Mon Sep 17 00:00:00 2001
+From: Richard E Barber <kd6kxr@gmail.com>
+Date: Sun, 19 May 2024 16:39:28 -0700
+Subject: [PATCH 2/2] removes redundant jpeg error message
+
+Co-authored-by: Lawrence37 <45837045+Lawrence37@users.noreply.github.com>
+---
+ rtengine/jdatasrc.cc | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/rtengine/jdatasrc.cc b/rtengine/jdatasrc.cc
+index a0d12657f..96b6f83b6 100644
+--- a/rtengine/jdatasrc.cc
++++ b/rtengine/jdatasrc.cc
+@@ -399,10 +399,6 @@ my_jpeg_std_error (struct jpeg_error_mgr * err)
+ 
+     /* override these functions */
+     err->error_exit = my_error_exit;
+-    err->emit_message = emit_message;
+-    err->output_message = output_message;
+-    err->format_message = format_message;
+-    err->reset_error_mgr = reset_error_mgr;
+ 
+     return err;
+ }
+-- 
+2.45.1
+

--- a/com.rawtherapee.RawTherapee.yaml
+++ b/com.rawtherapee.RawTherapee.yaml
@@ -208,6 +208,7 @@ modules:
       - type: patch
         paths:
           - RawTherapee-appdata.patch
+          - 0001-jpeg-turbo.patch
       # Allow to use GIMP from the host as an external tool to edit photos
       - type: script
         commands:


### PR DESCRIPTION
libjpeg-turbo 3.0.3 dropped `jpeg_std_message_table` which was a private API. This patch should fix the issue whenever fdsdk and thus GNOME 45 gets updated via https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/merge_requests/19507

If this does not work, the solution is to build against libjpeg-turbo 3.0.2